### PR TITLE
Read script descriptions from README at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # `cliffs`
 
-`cliffs` is a small CLI built on [`brick`] that makes 
-interacting with [scripts to rule them all] (STRTA) easier.
+`cliffs` is a small CLI built on [`brick`] that makes interacting with [scripts
+to rule them all] (STRTA) easier.
 
-It is oriented around three features that should alleviate some
-common pain points:
+It is oriented around three features that should alleviate some common pain
+points:
 
 | Pain Point                                     | `cliffs` help                                                    |
 | :--------------------------------------------- | ---------------------------------------------------------------- |
@@ -12,17 +12,39 @@ common pain points:
 | Remembering what arguments scripts take        | Rendering `--help` output with a hotkey                          |
 | Separating help from where you run the command | Providing a small terminal for command submission with the table |
 
-You can see an example by running `cliffs` in this directory. Running the executable will get you an interactive table of scripts like:
+You can see an example by running `cliffs` in this directory. Running the
+executable will get you an interactive table of scripts like:
 
 ```
-┏━━━━━━━━━━━━━━━━Scripts━━━━━━━━━━━━━━━━┓
-┃   bootstrap   ┃ description goes here ┃
-┃   server      ┃ description goes here ┃
-┃   update      ┃ description goes here ┃
-┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+┏━━━━━━━━━━━━━━━━━━━━━━━Scripts━━━━━━━━━━━━━━━━━━━━━━┓
+┃   bootstrap   ┃ Set stuff up                       ┃
+┃   server      ┃ Start servers                      ┃
+┃   update      ┃ Update dependencies and containers ┃
+┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 ```
 
-You can press the up / down arrow to select different scripts.
+You can press the up / down arrow to select different scripts, which will update
+the `Help output` box (not shown in paste above).
 
-[`brick`]: https://github.com/jtdaugherty/brick
-[scripts to rule them all]: https://github.com/github/scripts-to-rule-them-all
+## Script descriptions
+
+Scripts can have short descriptions as well as their help text. You can include
+such information in a table in a README. Your README must live in a file called
+`README.md`. `cliffs` will show the description from the table in the README for
+any scripts that have them. To detect the short descriptions automatically, your
+README _must_ have a table with two columns named "Script Name" and
+"Description" somewhere in the README. In the future this requirement may be
+relaxed, for example by taking arguments for the column headers and the README
+location, but for now the requirements are strict.
+
+An example table is below:
+
+| Script Name | Description                        |
+| :---------- | ---------------------------------- |
+| bootstrap   | Set stuff up                       |
+| server      | Start servers                      |
+| update      | Update dependencies and containers |
+
+
+[`brick`]: https://github.com/jtdaugherty/brick [scripts to rule them all]:
+https://github.com/github/scripts-to-rule-them-all

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -10,6 +10,7 @@ import Brick.AttrMap
   )
 import qualified Brick.Main as M
 import Control.Monad (void)
+import qualified Data.Map.Strict as M
 import Data.Text (pack)
 import qualified Graphics.Vty as V
 import Lib
@@ -19,6 +20,7 @@ import Lib
     drawUi,
     emphAttr,
   )
+import ScriptMetadata (findScriptDescriptions)
 import System.Directory (listDirectory)
 import System.FilePath (takeFileName)
 
@@ -36,9 +38,16 @@ app =
 
 main :: IO ()
 main = do
+  descMap <- findScriptDescriptions
   scriptFileNames <- listDirectory "./scripts"
-  let scripts =
+  let lookupDesc filePath =
+        foldr const "No description" $ descMap >>= \m -> M.lookup (pack $ takeFileName filePath) m
+      scripts =
         AppState
-          ((\n -> Script False (pack $ takeFileName n) "description goes here") <$> scriptFileNames)
+          ( ( \n ->
+                Script False (pack $ takeFileName n) (lookupDesc n)
+            )
+              <$> scriptFileNames
+          )
           Nothing
    in void $ M.defaultMain app scripts

--- a/cliffs.cabal
+++ b/cliffs.cabal
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       Lib
+      ScriptMetadata
   other-modules:
       Paths_cliffs
   hs-source-dirs:
@@ -33,7 +34,9 @@ library
   build-depends:
       base >=4.7 && <5
     , brick
+    , cmark-gfm
     , command
+    , containers
     , directory
     , filepath
     , microlens
@@ -53,7 +56,9 @@ executable cliffs-exe
       base >=4.7 && <5
     , brick
     , cliffs
+    , cmark-gfm
     , command
+    , containers
     , directory
     , filepath
     , microlens
@@ -74,7 +79,9 @@ test-suite cliffs-test
       base >=4.7 && <5
     , brick
     , cliffs
+    , cmark-gfm
     , command
+    , containers
     , directory
     , filepath
     , microlens

--- a/haskell.nix
+++ b/haskell.nix
@@ -3,7 +3,9 @@ with import <nixpkgs> { };
 pkgs.haskellPackages.ghcWithPackages (ps: with ps; [
   # actual project dependencies
   brick
+  cmark-gfm
   command
+  containers
   directory
   filepath
   microlens

--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,9 @@ ghc-options:
 dependencies:
   - base >= 4.7 && < 5
   - brick
+  - cmark-gfm
   - command
+  - containers
   - directory
   - filepath
   - microlens

--- a/src/ScriptMetadata.hs
+++ b/src/ScriptMetadata.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ScriptMetadata (findScriptDescriptions, readScriptDescriptions) where
+
+import CMarkGFM (Node (Node), NodeType (CODE, LINK, TABLE, TABLE_ROW, TEXT), commonmarkToNode, extTable)
+-- import qualified Data.Map.Strict as M
+-- import Data.Text (Text)
+
+import qualified Data.Map.Lazy as M
+import Data.Text (Text)
+import Data.Text.IO as T (readFile)
+
+findScriptDescriptions :: IO (Maybe (M.Map Text Text))
+findScriptDescriptions =
+  readScriptDescriptions . commonmarkToNode [] [extTable]
+    <$> T.readFile "README.md"
+
+rowToPair :: Node -> Maybe (M.Map Text Text)
+rowToPair (Node _ TABLE_ROW (c1 : c2 : _)) =
+  M.singleton <$> getContainedText c1 <*> getContainedText c2
+rowToPair _ = Nothing
+
+-- keys should be extracted from:
+-- plain text script names (e.g. "update")
+-- code script names (e.g. "`update`")
+-- code or plain text script names that links to the script (e.g. "[`update`](./scripts/update)")
+--
+-- descriptions should always be treated as plain text
+extractMap :: Node -> Maybe (M.Map Text Text)
+extractMap (Node _ (TABLE _) (_ : rows)) =
+  -- for each row, grab the first and second cells.
+  -- treat the first as the script name and second as the description
+  -- ignore a few kinds of failure:
+  --   - if there isn't a second cell (possible! even parses correctly!)
+  --   - if we can't get text out for some reason
+  -- at this stage the table is assumed to be well-formed and cooperative with
+  -- our goals
+  mconcat $ rowToPair <$> rows
+extractMap _ = Nothing
+
+descriptionColumnName :: Text
+descriptionColumnName = "Description"
+
+scriptNameColumnName :: Text
+scriptNameColumnName = "Script Name"
+
+getContainedText :: Node -> Maybe Text
+getContainedText (Node _ _ (Node _ (TEXT t) _ : _)) = Just t
+getContainedText (Node _ _ (Node _ (CODE t) _ : _)) = Just t
+getContainedText (Node _ _ (Node _ (LINK _ _) (linkText : _) : _)) =
+  getContainedText linkText
+getContainedText _ = Nothing
+
+checkTableHeader :: Node -> Bool
+checkTableHeader (Node _ TABLE_ROW (c1 : c2 : _)) =
+  getContainedText c1 == Just scriptNameColumnName
+    && getContainedText c2 == Just descriptionColumnName
+checkTableHeader _ = False
+
+checkTable :: Node -> Bool
+checkTable (Node _ (TABLE _) (hr : _)) = checkTableHeader hr
+checkTable _ = False
+
+readScriptDescriptions :: Node -> Maybe (M.Map Text Text)
+readScriptDescriptions table@(Node _ (TABLE _) _) =
+  if checkTable table then extractMap table else Nothing
+readScriptDescriptions (Node _ _ []) =
+  Nothing
+readScriptDescriptions (Node _ _ (h : t)) =
+  go h t
+  where
+    go node [] = readScriptDescriptions node
+    go node (h' : t') = case readScriptDescriptions node of
+      descs@(Just _) -> descs
+      Nothing -> go h' t'


### PR DESCRIPTION
This PR reads a table of script descriptions from a README in the current working directory when `cliffs` starts. An example table is included in the repo, which is used to fill in the former `description goes here` comments. The video below shows the table in this repo's README, then starts `cliffs`, where the same descriptions are filled in in the table:

https://user-images.githubusercontent.com/5702984/139554151-831a72cf-9519-4174-b6b0-262a69a43991.mp4

Closes #1 