### PR TITLE
Add release + binary upload for tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,9 +34,9 @@ jobs:
         run: echo "::set-output name=BINARY_PATH::$(nix-store -r $(which cliffs))"
 
       - name: Copy binary to os-namespaced file
-        run: cp ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs $(pwd)/cliffs-${{ matrix.os }}
+        run: cp ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs ./cliffs-${{ matrix.os }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: $(pwd)/cliffs-${{ matrix.os }}
+          files: ./cliffs-${{ matrix.os }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,10 +33,10 @@ jobs:
         id: package-location
         run: echo "::set-output name=BINARY_PATH::$(nix-store -r $(which cliffs))"
 
-      - name: Echo binary location
-        run: echo ${{ steps.package-location.outputs.BINARY_PATH }}
+      - name: Copy binary to os-namespaced file
+        run: cp ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs $(pwd)/cliffs-${{ matrix.os }}
 
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs
+          files: $(pwd)/cliffs-${{ matrix.os }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,15 +32,12 @@ jobs:
 
       - name: Locate package binary
         id: package-location
-        run: echo "::set-output name=BINARY_PATH::$(which cliffs)"
+        run: echo "::set-output name=BINARY_PATH::nix-store -r $(which cliffs)"
 
       - name: Echo binary location
         run: echo ${{ steps.package-location.outputs.BINARY_PATH }}
 
-      - name: Read binary location link
-        run: readlink -f ${{ steps.package-location.outputs.BINARY_PATH }}
-
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:
-          files: ${{ steps.package-location.outputs.BINARY_PATH }}
+          files: ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Locate package binary
         id: package-location
-        run: echo "::set-output name=BINARY_PATH::nix-store -r $(which cliffs)"
+        run: echo "::set-output name=BINARY_PATH::$(nix-store -r $(which cliffs))"
 
       - name: Echo binary location
         run: echo ${{ steps.package-location.outputs.BINARY_PATH }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,7 +1,6 @@
 name: CD
 
 on:
-  pull_request:
   push:
     tags:
       - v*

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Echo binary location
         run: echo ${{ steps.package-location.outputs.BINARY_PATH }}
 
+      - name: Read binary location link
+        run: readlink -f ${{ steps.package-location.outputs.BINARY_PATH }}
+
       - name: Create release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,6 +1,7 @@
 name: CD
 
 on:
+  pull_request:
   push:
     tags:
       - v*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Nix expressions evaluate to a real derivation and a shell [#11](https://github.com/jisantuc/cliffs/pull/11)
+- Determined non-link binary path using nix-store [#14](https://github.com/jisantuc/cliffs/pull/14)


### PR DESCRIPTION
This PR uses the `nix-store` to determine the absolute path to the built binary instead of just using `which cliffs`. `which cliffs` in a nix environment resolves to the link. In linux you can use `readlink -f` to canonicalize the link, but that was never going to work for the mac build, but `nix-store -r` resolves the root of the derivation in linux and macos.

You can see a successfully built release artifacts [here](https://github.com/jisantuc/cliffs/releases/tag/v0.0.1g)

Closes #8 