### PR TITLE
Document release process and remove binary upload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,23 +20,5 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
-      - name: Use cachix
-        uses: cachix/cachix-action@v10
-        with:
-          name: jisantuc
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Install package
-        run: nix-env -i -f default.nix
-
-      - name: Locate package binary
-        id: package-location
-        run: echo "::set-output name=BINARY_PATH::$(nix-store -r $(which cliffs))"
-
-      - name: Copy binary to os-namespaced file
-        run: cp ${{ steps.package-location.outputs.BINARY_PATH }}/bin/cliffs ./cliffs-${{ matrix.os }}
-
       - name: Create release
         uses: softprops/action-gh-release@v1
-        with:
-          files: ./cliffs-${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.0.0-alpha] - 2021-11-15
 ### Added
 - Show help text on script name hover [#5](https://github.com/jisantuc/cliffs/pull/5)
 - Created CI workflow and tested parsing a few known inputs [#9](https://github.com/jisantuc/cliffs/pull/9)
@@ -16,4 +14,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Determined non-link binary path using nix-store [#14](https://github.com/jisantuc/cliffs/pull/14)
 
 [Unreleased]: https://github.com/jisantuc/cliffs/compare/v1.0.0-alpha...HEAD
-[1.0.0-alpha]: https://github.com/jisantuc/cliffs/releases/tags/v1.0.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-alpha] - 2021-11-15
 ### Added
 - Show help text on script name hover [#5](https://github.com/jisantuc/cliffs/pull/5)
 - Created CI workflow and tested parsing a few known inputs [#9](https://github.com/jisantuc/cliffs/pull/9)
@@ -12,3 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Nix expressions evaluate to a real derivation and a shell [#11](https://github.com/jisantuc/cliffs/pull/11)
 - Determined non-link binary path using nix-store [#14](https://github.com/jisantuc/cliffs/pull/14)
+
+[Unreleased]: https://github.com/jisantuc/cliffs/compare/v1.0.0-alpha...HEAD
+[1.0.0-alpha]: https://github.com/jisantuc/cliffs/releases/tags/v1.0.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0-alpha] - 2021-11-15
 ### Added
 - Show help text on script name hover [#5](https://github.com/jisantuc/cliffs/pull/5)
 - Created CI workflow and tested parsing a few known inputs [#9](https://github.com/jisantuc/cliffs/pull/9)
@@ -14,3 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Determined non-link binary path using nix-store [#14](https://github.com/jisantuc/cliffs/pull/14)
 
 [Unreleased]: https://github.com/jisantuc/cliffs/compare/v1.0.0-alpha...HEAD
+[1.0.0-alpha]: https://github.com/jisantuc/cliffs/releases/tags/v1.0.0-alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.0.0-alpha] - 2021-11-15
 ### Added
 - Show help text on script name hover [#5](https://github.com/jisantuc/cliffs/pull/5)
 - Created CI workflow and tested parsing a few known inputs [#9](https://github.com/jisantuc/cliffs/pull/9)
+- Determined and documented a release process and better ideas about binaries [#15](https://github.com/jisantuc/cliffs/pull/15)
 
 ### Changed
 - Nix expressions evaluate to a real derivation and a shell [#11](https://github.com/jisantuc/cliffs/pull/11)
 - Determined non-link binary path using nix-store [#14](https://github.com/jisantuc/cliffs/pull/14)
 
 [Unreleased]: https://github.com/jisantuc/cliffs/compare/v1.0.0-alpha...HEAD
-[1.0.0-alpha]: https://github.com/jisantuc/cliffs/releases/tags/v1.0.0-alpha

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ An example table is below:
 
 ## Releases
 
-Relases are handled by [`chan`] and [GitHub Actions]. To create a new release:
+Relases are handled by [`chan`] and GitHub Actions. To create a new release:
 
 - rotate the changelog: `chan release v<VERSION>`
 - commit the release: `git commit -am "Update changelog for <VERSION>`
@@ -58,9 +58,18 @@ Relases are handled by [`chan`] and [GitHub Actions]. To create a new release:
 - create the GitHub release after the build completes
 
 Everything up to creating the GitHub release after the build is handled by the
-`scripts/release` script. The GitHub actions that create the artifacts will
-create the release itself, but it's up to you to fill in the CHANGELOG.
+`scripts/release` script. The GitHub action will create the release itself.
+
+After the release exists, you should:
+
+- paste the changelog for this release
+- add an installation command like: `nix-env -i -f
+  https://github.com/jisantuc/cliffs/archive/refs/tags/VERSION.zip`. This
+  command will work across platforms where `nix` is installed, so MacOS / Linux
+  / NixOS / anyone else with nix should be able to call the install command and
+  get a working executable.
 
 [`brick`]: https://github.com/jtdaugherty/brick
 [scripts to rule them all]:
 https://github.com/github/scripts-to-rule-them-all
+[`chan`]: https://www.npmjs.com/package/@geut/chan

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Relases are handled by [`chan`] and [GitHub Actions]. To create a new release:
 - push the tag: `git push origin --tags v<VERSION>`
 - create the GitHub release after the build completes
 
-Everything up to creating the GitHub release after the build is handled by the `scripts/release` script.
+Everything up to creating the GitHub release after the build is handled by the
+`scripts/release` script. The GitHub actions that create the artifacts will
+create the release itself, but it's up to you to fill in the CHANGELOG.
 
 [`brick`]: https://github.com/jtdaugherty/brick
 [scripts to rule them all]:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ An example table is below:
 Relases are handled by [`chan`] and GitHub Actions. To create a new release:
 
 - rotate the changelog: `chan release v<VERSION>`
+- bump versions in `package.yaml` and `cliffs.cabal` (the second with `hpack`)
 - commit the release: `git commit -am "Update changelog for <VERSION>`
 - tag the release: `git tag -S -a v<VERSION> -m "Release v<VERSION>"`
 - push the tag: `git push origin --tags v<VERSION>`

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ An example table is below:
 | server      | Start servers                      |
 | update      | Update dependencies and containers |
 
+## Releases
+
+Relases are handled by [`chan`] and [GitHub Actions]. To create a new release:
+
+- rotate the changelog: `chan release v<VERSION>`
+- commit the release: `git commit -am "Update changelog for <VERSION>`
+- tag the release: `git tag -S -a v<VERSION> -m "Release v<VERSION>"`
+- push the tag: `git push origin --tags v<VERSION>`
+- create the GitHub release after the build completes
+
 
 [`brick`]: https://github.com/jtdaugherty/brick
 [scripts to rule them all]:

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ location, but for now the requirements are strict.
 
 An example table is below:
 
-| Script Name | Description                        |
-| :---------- | ---------------------------------- |
-| bootstrap   | Set stuff up                       |
-| server      | Start servers                      |
-| update      | Update dependencies and containers |
+| Script Name | Description                                         |
+| :---------- | --------------------------------------------------- |
+| release     | Create tags and CHANGELOG entries for a new release |
+| bootstrap   | Set stuff up                                        |
+| server      | Start servers                                       |
+| update      | Update dependencies and containers                  |
+
 
 ## Releases
 
@@ -55,6 +57,7 @@ Relases are handled by [`chan`] and [GitHub Actions]. To create a new release:
 - push the tag: `git push origin --tags v<VERSION>`
 - create the GitHub release after the build completes
 
+Everything up to creating the GitHub release after the build is handled by the `scripts/release` script.
 
 [`brick`]: https://github.com/jtdaugherty/brick
 [scripts to rule them all]:

--- a/README.md
+++ b/README.md
@@ -46,5 +46,6 @@ An example table is below:
 | update      | Update dependencies and containers |
 
 
-[`brick`]: https://github.com/jtdaugherty/brick [scripts to rule them all]:
+[`brick`]: https://github.com/jtdaugherty/brick
+[scripts to rule them all]:
 https://github.com/github/scripts-to-rule-them-all

--- a/scripts/release
+++ b/scripts/release
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -u
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Create a release by:
+
+- rotating the changelog
+- creating a tag for the release
+- creating a GitHub release for the tag
+- pushing the tag and changes to GitHub
+"
+}
+
+function failVersion() {
+    echo "Version $1 is not a valid semver like v1.0.0"
+    exit 1
+}
+
+function checkVersion() {
+    echo "$1" | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+"
+}
+
+function chan() {
+    docker run -e GITHUB_TOKEN="${GITHUB_TOKEN}" -v "$(pwd)":/opt/src jisantuc/chan:latest --allow-prerelease "$@"
+}
+
+function release() {
+
+    version=$1
+
+    checkVersion "$version"
+    versionCheck=$?
+
+    if [[ versionCheck -eq 1 ]]; then
+        failVersion "$version"
+    fi
+
+    # After we know that the version is valid, we want to fail
+    # on any other errors
+    set -e
+
+    chan release "$version"
+
+    git add CHANGELOG.md
+
+    git commit -m "Release version $version"
+
+    git push origin "$(git branch --show-current)"
+
+    git tag -s -a "$version" -m "Release $version"
+
+    git push origin --tags "$version"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        release "${1}"
+    fi
+fi

--- a/scripts/release
+++ b/scripts/release
@@ -23,8 +23,8 @@ function checkVersion() {
     echo "$1" | grep "v[0-9]\+\.[0-9]\+\.[0-9]\+"
 }
 
-function chan() {
-    docker run -e GITHUB_TOKEN="${GITHUB_TOKEN}" -v "$(pwd)":/opt/src jisantuc/chan:latest --allow-prerelease "$@"
+function chanRelease() {
+    docker run -e GITHUB_TOKEN="${GITHUB_TOKEN}" -v "$(pwd)":/opt/src jisantuc/chan:latest release --allow-prerelease "$@"
 }
 
 function release() {
@@ -42,7 +42,7 @@ function release() {
     # on any other errors
     set -e
 
-    chan release "$version"
+    chanRelease "$version"
 
     git add CHANGELOG.md
 

--- a/scripts/release
+++ b/scripts/release
@@ -44,7 +44,13 @@ function release() {
 
     chanRelease "$version"
 
-    git add CHANGELOG.md
+    versionNoV=$(echo "$version" | sed 's/v\(.*\)/\1/')
+
+    sed -i "s/^version:\( \+\)\([0-9]\+\.[0-9]\+\.[0-9]\+\)/version:\1$versionNoV/" package.yaml
+
+    nix-shell --run hpack
+
+    git add CHANGELOG.md package.yaml cliffs.cabal
 
     git commit -m "Release version $version"
 


### PR DESCRIPTION
This PR:

- adds docs on how to do releases
- removes binary uploads from the release process, since with pre-built binaries in the Nix cache installation goes _really fast_
- adds a release script to get through the boring CLI entry parts of the release