### PR TITLE
Parse mixed plain, code, and link text as siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Mixed format text no longer parses as the first element [#17](https://github.com/jisantuc/cliffs/pull/17)
 
 ## [0.0.1] - 2021-11-15
 ### Added

--- a/cliffs.nix
+++ b/cliffs.nix
@@ -1,6 +1,7 @@
 { mkDerivation
 , base
 , brick
+, cabal-install
 , cmark-gfm
 , command
 , containers
@@ -34,7 +35,7 @@ mkDerivation {
     vector
     vty
   ];
-  libraryToolDepends = [ hpack ];
+  libraryToolDepends = [ hpack cabal-install ];
   executableHaskellDepends = [
     base
     brick

--- a/src/ScriptMetadata.hs
+++ b/src/ScriptMetadata.hs
@@ -63,8 +63,10 @@ getContainedText :: Node -> Maybe Text
 getContainedText (Node _ (TEXT t) _) = Just . T.strip $ t
 getContainedText (Node _ (CODE t) _) = Just . T.strip $ t
 getContainedText (Node _ (LINK _ _) (linkText : _)) = getContainedText linkText
-getContainedText (Node _ _ (Node _ (TEXT t) _ : siblings)) = Just . joinMaybeTexts $ (Just . T.strip $ t) : (getContainedText <$> siblings)
-getContainedText (Node _ _ (Node _ (CODE t) _ : siblings)) = Just . joinMaybeTexts $ (Just . T.strip $ t) : (getContainedText <$> siblings)
+getContainedText (Node _ _ (Node _ (TEXT t) _ : siblings)) =
+  Just . joinMaybeTexts $ (Just . T.strip $ t) : (getContainedText <$> siblings)
+getContainedText (Node _ _ (Node _ (CODE t) _ : siblings)) =
+  Just . joinMaybeTexts $ (Just . T.strip $ t) : (getContainedText <$> siblings)
 getContainedText (Node _ _ (Node _ (LINK _ _) (linkText : _) : _)) =
   getContainedText linkText
 getContainedText _ = Nothing

--- a/src/ScriptMetadata.hs
+++ b/src/ScriptMetadata.hs
@@ -9,7 +9,6 @@ import CMarkGFM (Node (Node), NodeType (CODE, LINK, TABLE, TABLE_ROW, TEXT), com
 import qualified Data.Map.Lazy as M
 import Data.Text (Text)
 import Data.Text.IO as T (readFile)
-import Debug.Trace
 
 findScriptDescriptions :: IO (Maybe (M.Map Text Text))
 findScriptDescriptions =
@@ -51,8 +50,7 @@ getContainedText (Node _ (CODE t) _) = Just t
 getContainedText (Node _ _ (Node _ (TEXT t) _ : _)) = Just t
 getContainedText (Node _ _ (Node _ (CODE t) _ : _)) = Just t
 getContainedText (Node _ _ (Node _ (LINK _ _) (linkText : _) : _)) =
-  trace ("LINK TEXT: " <> show linkText) $
-    getContainedText linkText
+  getContainedText linkText
 getContainedText _ = Nothing
 
 checkTableHeader :: Node -> Bool

--- a/test/ScriptMetadataSpec.hs
+++ b/test/ScriptMetadataSpec.hs
@@ -32,6 +32,16 @@ spec = do
       textTest linkText "baz"
     it "extracts text from code in a link" $
       textTest linkCodeText "qux"
+    it "extracts text from mixed plain and code text" $
+      textTest plainAndCode "foo bar"
+    it "extracts text from mixed plain and link text" $
+      textTest plainAndLink "foo bar"
+    it "extracts text from mixed code and link text" $
+      textTest codeAndLink "foo bar"
+    it "extracts text from mixed code and code link text" $
+      textTest codeAndCodeLink "foo bar"
+    it "extracts text from mixed plain and link and code text" $
+      textTest plainAndLinkAndCode "foo bar baz"
 
 tableTest :: Text -> M.Map Text Text -> Expectation
 tableTest t m =
@@ -53,6 +63,21 @@ tableWithCodeName = "| Script Name | Description |\n| :---------- | ----------- 
 
 tableWithCodeLinkName :: Text
 tableWithCodeLinkName = "| Script Name | Description |\n| :---------- | ----------- |\n| [`car`](./scripts/car)  | truck |\n"
+
+plainAndCode :: Text
+plainAndCode = "foo `bar`"
+
+plainAndLink :: Text
+plainAndLink = "foo [bar](./bar.txt)"
+
+codeAndLink :: Text
+codeAndLink = "`foo` [bar](./bar.txt)"
+
+codeAndCodeLink :: Text
+codeAndCodeLink = "`foo` [`bar`](./bar.txt)"
+
+plainAndLinkAndCode :: Text
+plainAndLinkAndCode = "foo [`bar`](./bar.txt) `baz`"
 
 plainText :: Text
 plainText = "foo"


### PR DESCRIPTION
This PR makes it so that if you have markdown like:

```markdown
foo `bar` [baz](./baz.txt)
```

text extraction gets you `foo bar baz` instead of `foo `.

Closes #12