### PR TITLE
Substitute version in cliffs.nix on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Mixed format text no longer parses as the first element [#17](https://github.com/jisantuc/cliffs/pull/17)
+- Release script also bumps version of nix derivation [#19](https://github.com/jisantuc/cliffs/pull/19)
 
 ## [0.0.1] - 2021-11-15
 ### Added

--- a/cliffs.nix
+++ b/cliffs.nix
@@ -18,7 +18,7 @@
 }:
 mkDerivation {
   pname = "cliffs";
-  version = "0.1.0.0";
+  version = "0.0.1";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/scripts/release
+++ b/scripts/release
@@ -48,9 +48,11 @@ function release() {
 
     sed -i "s/^version:\( \+\)\([0-9]\+\.[0-9]\+\.[0-9]\+\)/version:\1$versionNoV/" package.yaml
 
+    sed -i "s/^\( \+\)version = \"[0-9]\+\.[0-9]\+\.[0-9]\+\"/\1version = \"$versionNoV\"/" cliffs.nix
+
     nix-shell --run hpack
 
-    git add CHANGELOG.md package.yaml cliffs.cabal
+    git add CHANGELOG.md package.yaml cliffs.cabal cliffs.nix
 
     git commit -m "Release version $version"
 


### PR DESCRIPTION
This PR adds a `sed` command for bumping the version in `cliffs.nix` to the command for bumping it in `package.yaml`.
It also resets the `cliffs.nix` version to the current tag.

Testing
-----

- throw a nice `exit 1` after the second `sed` command
- run `scripts/release` for a version that's not yet in the changelog
- `git diff cliffs.nix` and make sure the version is bumped

Closes #16 