### PR TITLE
Make cabal a shell only dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Mixed format text no longer parses as the first element [#17](https://github.com/jisantuc/cliffs/pull/17)
 - Release script also bumps version of nix derivation [#19](https://github.com/jisantuc/cliffs/pull/19)
+- Removed cabal from default build [#20](https://github.com/jisantuc/cliffs/pull/20)
 
 ## [0.0.1] - 2021-11-15
 ### Added

--- a/cliffs.nix
+++ b/cliffs.nix
@@ -14,6 +14,7 @@
 , text
 , vector
 , vty
+, extraToolDeps ? [ ]
 }:
 mkDerivation {
   pname = "cliffs";
@@ -34,7 +35,7 @@ mkDerivation {
     vector
     vty
   ];
-  libraryToolDepends = [ hpack ];
+  libraryToolDepends = [ hpack ] ++ extraToolDeps;
   executableHaskellDepends = [
     base
     brick

--- a/cliffs.nix
+++ b/cliffs.nix
@@ -1,7 +1,6 @@
 { mkDerivation
 , base
 , brick
-, cabal-install
 , cmark-gfm
 , command
 , containers
@@ -35,7 +34,7 @@ mkDerivation {
     vector
     vty
   ];
-  libraryToolDepends = [ hpack cabal-install ];
+  libraryToolDepends = [ hpack ];
   executableHaskellDepends = [
     base
     brick

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,5 @@
-{ nixpkgs ? import <nixpkgs> { }, compiler ? "ghc8107" }:
-nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./cliffs.nix { }
+{ nixpkgs ? import <nixpkgs> { }
+, compiler ? "ghc8107"
+, extraToolDeps ? [ ]
+}:
+nixpkgs.pkgs.haskell.packages.${compiler}.callPackage ./cliffs.nix { extraToolDeps = extraToolDeps; }

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,2 @@
 { nixpkgs ? import <nixpkgs> { }, compiler ? "ghc8107" }:
-(import ./default.nix { inherit nixpkgs compiler; }).env
+(import ./default.nix { extraToolDeps = [ nixpkgs.cabal-install ]; inherit nixpkgs compiler; }).env


### PR DESCRIPTION
This PR makes it so that `cabal-install` isn't required for the package build. This makes the dependency fetch much smaller and I think will keep it from being fetched for people who just want to install the package instead of develop on it.

Notes
-----

I _think_, one time, that `cabal-install` as a dep required compiling all of cabal's source deps, which took a long time and I didn't like it. The overall impact on packages to fetch and size of things to fetch isn't really that significant 🤔

This wouldn't be necessary at all if I knew how to run tests using `nix` but 🤷🏻‍♂️ that's a puzzle for future me

Testing
----

- ensure you still have `cabal` available when you run `nix-shell`
- confirm that without `cabal-install` passed in `shell.nix` in `extraToolDeps` you _don't_ have `cabal` available in the shell

Closes #18 