### PR TITLE
Add CLI options for script name and description columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release script also bumps version of nix derivation [#19](https://github.com/jisantuc/cliffs/pull/19)
 - Removed cabal from default build [#20](https://github.com/jisantuc/cliffs/pull/20)
 
+### Added
+- Allowed configuration of column and description names [#22](https://github.com/jisantuc/cliffs/pull/22)
+
 ## [0.0.1] - 2021-11-15
 ### Added
 - Show help text on script name hover [#5](https://github.com/jisantuc/cliffs/pull/5)

--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ such information in a table in a README. Your README must live in a file called
 `README.md`. `cliffs` will show the description from the table in the README for
 any scripts that have them. To detect the short descriptions automatically, your
 README _must_ have a table with two columns named "Script Name" and
-"Description" somewhere in the README. In the future this requirement may be
-relaxed, for example by taking arguments for the column headers and the README
-location, but for now the requirements are strict.
+"Description" somewhere in the README. 
 
 An example table is below:
 
@@ -46,6 +44,12 @@ An example table is below:
 | server      | Start servers                                       |
 | update      | Update dependencies and containers                  |
 
+If you have a similar table but with different names, you can specify those at
+runtime! You can use the `--script-name-column` / `-s` option to control
+the name of the column where script names can be found, and the
+`--description-column` / `-d` option to control the name of the column
+where the descriptions are found. Both have defaults in case your names
+match "Script Name" and "Description" already.
 
 ## Releases
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -11,7 +11,7 @@ import Brick.AttrMap
 import qualified Brick.Main as M
 import Control.Monad (void)
 import qualified Data.Map.Strict as M
-import Data.Text (pack)
+import Data.Text (Text, pack)
 import qualified Graphics.Vty as V
 import Lib
   ( AppState (..),
@@ -20,9 +20,18 @@ import Lib
     drawUi,
     emphAttr,
   )
+import Options.Applicative (Parser)
 import ScriptMetadata (findScriptDescriptions)
 import System.Directory (listDirectory)
 import System.FilePath (takeFileName)
+
+data Options = Options
+  { nameColumnName :: Text,
+    descriptionColumnName :: Text
+  }
+
+options :: Parser Options
+options = undefined
 
 app :: M.App AppState (IO ()) ()
 app =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -25,6 +25,7 @@ import Options.Applicative
     execParser,
     fullDesc,
     header,
+    help,
     helper,
     info,
     long,
@@ -47,8 +48,20 @@ data Options = Options
 options :: Parser Options
 options =
   Options
-    <$> strOption (long "script-name-column" <> short 's' <> showDefault <> value "Script Name")
-    <*> strOption (long "description-column" <> short 'd' <> showDefault <> value "Description")
+    <$> strOption
+      ( long "script-name-column"
+          <> short 's'
+          <> showDefault
+          <> value "Script Name"
+          <> help "Name of the README table column holding the name of scripts"
+      )
+    <*> strOption
+      ( long "description-column"
+          <> short 'd'
+          <> showDefault
+          <> value "Description"
+          <> help "Name of the README table column holding the descriptions of scripts"
+      )
 
 app :: M.App AppState (IO ()) ()
 app =

--- a/cliffs.cabal
+++ b/cliffs.cabal
@@ -40,6 +40,7 @@ library
     , directory
     , filepath
     , microlens
+    , optparse-applicative
     , text
     , vector
     , vty
@@ -62,6 +63,7 @@ executable cliffs
     , directory
     , filepath
     , microlens
+    , optparse-applicative
     , text
     , vector
     , vty
@@ -88,6 +90,7 @@ test-suite cliffs-test
     , hspec
     , hspec-discover
     , microlens
+    , optparse-applicative
     , text
     , vector
     , vty

--- a/cliffs.nix
+++ b/cliffs.nix
@@ -11,6 +11,7 @@
 , hspec-discover
 , lib
 , microlens
+, optparse-applicative
 , text
 , vector
 , vty
@@ -31,6 +32,7 @@ mkDerivation {
     directory
     filepath
     microlens
+    optparse-applicative
     text
     vector
     vty

--- a/package.yaml
+++ b/package.yaml
@@ -32,6 +32,7 @@ dependencies:
   - directory
   - filepath
   - microlens
+  - optparse-applicative
   - text
   - vector
   - vty

--- a/test/ScriptMetadataSpec.hs
+++ b/test/ScriptMetadataSpec.hs
@@ -20,7 +20,8 @@ spec = do
     it "extracts keys from code in links" $
       tableTest tableWithCodeLinkName (M.singleton "car" "truck")
     it "doesn't extract anything from tables with unexpected column headings" $
-      (readScriptDescriptions . commonmarkToNode [] [extTable] $ badHeadingsText) `shouldBe` Nothing
+      (readScriptDescriptions "Script Name" "Description" . commonmarkToNode [] [extTable] $ badHeadingsText)
+        `shouldBe` Nothing
     it "ignores bad rows but collects good ones" $
       tableTest tableWithABadRow (M.fromList [("foo", "bar"), ("car", "truck")])
   describe "Text extractions" $ do
@@ -45,7 +46,7 @@ spec = do
 
 tableTest :: Text -> M.Map Text Text -> Expectation
 tableTest t m =
-  (readScriptDescriptions . commonmarkToNode [] [extTable] $ t) `shouldBe` (Just m)
+  (readScriptDescriptions "Script Name" "Description" . commonmarkToNode [] [extTable] $ t) `shouldBe` (Just m)
 
 textTest :: Text -> Text -> Expectation
 textTest markdownText expectedText =


### PR DESCRIPTION
Overview
-----

This PR adds command line options so that you can run `--help` from the bin _and_ so that you can specify the column names if your README doesn't have the exact names I picked by default, e.g.:

```bash
$ cliffs --help 
cliffs

Usage: cliffs [-s|--script-name-column ARG] [-d|--description-column ARG]
  Launch an interactive terminal UI for inspecting scripts-to-rule-them-all

Available options:
  -s,--script-name-column ARG
                           Name of the README table column holding the name of
                           scripts (default: "Script Name")
  -d,--description-column ARG
                           Name of the README table column holding the
                           descriptions of scripts (default: "Description")
  -h,--help                Show this help text
```

Testing
-----

- `nix-build` and note the path to `cliffs` reported (e.g. `/nix/store/mi5vhakmgyvx49y8qac2bq0j3sfikpgl-cliffs-0.0.1/bin`)
- run `cliffs` in a directory with scripts and a readme where the column names aren't the same (e.g. in [raster foundry](https://github.com/raster-foundry/raster-foundry/)) with args to make the name and description columns match up (i.e. `cliffs -d "Purpose"` for Raster Foundry, with `/nix/store/<hash>-cliffs-0.0.1/bin/cliffs` substitutded for `cliffs`)
- confirm you see the descriptions even though the column name is different from the default

Closes #13